### PR TITLE
Web888 bootloader si5351 driver

### DIFF
--- a/cfg/ports.tcl
+++ b/cfg/ports.tcl
@@ -2,42 +2,23 @@
 ### ADC
 
 create_bd_port -dir I -from 15 -to 0 adc_dat_a_i
-create_bd_port -dir I -from 15 -to 0 adc_dat_b_i
 
 create_bd_port -dir I adc_clk_p_i
 create_bd_port -dir I adc_clk_n_i
 
-create_bd_port -dir O adc_enc_p_o
-create_bd_port -dir O adc_enc_n_o
+create_bd_port -dir I adc_ofl_i
 
-create_bd_port -dir O adc_csn_o
+create_bd_port -dir O adc_dith_o
+create_bd_port -dir O adc_pga_o
 
-### DAC
+### Misc
 
-create_bd_port -dir O -from 13 -to 0 dac_dat_o
+create_bd_port -dir I pps_i
 
-create_bd_port -dir O dac_clk_o
-create_bd_port -dir O dac_rst_o
-create_bd_port -dir O dac_sel_o
-create_bd_port -dir O dac_wrt_o
-
-### PWM
-
-create_bd_port -dir O -from 3 -to 0 dac_pwm_o
-
-### XADC
-
-create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_analog_io_rtl:1.0 Vp_Vn
-create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_analog_io_rtl:1.0 Vaux0
-create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_analog_io_rtl:1.0 Vaux1
-create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_analog_io_rtl:1.0 Vaux9
-create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_analog_io_rtl:1.0 Vaux8
-
-### Expansion connector
-
-create_bd_port -dir IO -from 7 -to 0 exp_p_tri_io
-create_bd_port -dir IO -from 7 -to 0 exp_n_tri_io
+### Expand
+create_bd_port -dir IO -from 2 -to 0 exp_p_tri_io
+create_bd_port -dir IO -from 2 -to 0 exp_n_tri_io
 
 ### LED
 
-create_bd_port -dir O -from 7 -to 0 led_o
+create_bd_port -dir O led_o

--- a/cfg/ports.xdc
+++ b/cfg/ports.xdc
@@ -26,25 +26,23 @@ set_property PACKAGE_PIN V15 [get_ports {adc_dat_a_i[13]}]
 set_property PACKAGE_PIN T16 [get_ports {adc_dat_a_i[14]}]
 set_property PACKAGE_PIN V16 [get_ports {adc_dat_a_i[15]}]
 
-set_property IOSTANDARD LVCMOS18 [get_ports {adc_dat_b_i[*]}]
-set_property IOB TRUE [get_ports {adc_dat_b_i[*]}]
+### adc Overflow
+set_property IOSTANDARD LVCMOS18 [get_ports adc_ofl_i]
+set_property PACKAGE_PIN P20 [get_ports adc_ofl_i]
 
-set_property PACKAGE_PIN T17 [get_ports {adc_dat_b_i[0]}]
-set_property PACKAGE_PIN R16 [get_ports {adc_dat_b_i[1]}]
-set_property PACKAGE_PIN R18 [get_ports {adc_dat_b_i[2]}]
-set_property PACKAGE_PIN P16 [get_ports {adc_dat_b_i[3]}]
-set_property PACKAGE_PIN P18 [get_ports {adc_dat_b_i[4]}]
-set_property PACKAGE_PIN N17 [get_ports {adc_dat_b_i[5]}]
-set_property PACKAGE_PIN R19 [get_ports {adc_dat_b_i[6]}]
-set_property PACKAGE_PIN T20 [get_ports {adc_dat_b_i[7]}]
-set_property PACKAGE_PIN T19 [get_ports {adc_dat_b_i[8]}]
-set_property PACKAGE_PIN U20 [get_ports {adc_dat_b_i[9]}]
-set_property PACKAGE_PIN V20 [get_ports {adc_dat_b_i[10]}]
-set_property PACKAGE_PIN W20 [get_ports {adc_dat_b_i[11]}]
-set_property PACKAGE_PIN W19 [get_ports {adc_dat_b_i[12]}]
-set_property PACKAGE_PIN Y19 [get_ports {adc_dat_b_i[13]}]
-set_property PACKAGE_PIN W18 [get_ports {adc_dat_b_i[14]}]
-set_property PACKAGE_PIN Y18 [get_ports {adc_dat_b_i[15]}]
+### adc pga
+set_property IOSTANDARD LVCMOS33 [get_ports adc_pga_o]
+set_property SLEW SLOW [get_ports adc_pga_o]
+set_property DRIVE 8 [get_ports adc_pga_o]
+
+set_property PACKAGE_PIN K14 [get_ports adc_pga_o]
+
+### adc dither
+set_property IOSTANDARD LVCMOS33 [get_ports adc_dith_o]
+set_property SLEW SLOW [get_ports adc_dith_o]
+set_property DRIVE 8 [get_ports adc_dith_o]
+
+set_property PACKAGE_PIN J15 [get_ports adc_dith_o]
 
 # clock input
 
@@ -53,99 +51,18 @@ set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports adc_clk_n_i]
 set_property PACKAGE_PIN U18 [get_ports adc_clk_p_i]
 set_property PACKAGE_PIN U19 [get_ports adc_clk_n_i]
 
-# clock output
+### PPS Signal
 
-set_property IOSTANDARD LVCMOS18 [get_ports adc_enc_p_o]
-set_property IOSTANDARD LVCMOS18 [get_ports adc_enc_n_o]
+set_property IOSTANDARD LVCMOS33 [get_ports pps_i]
+set_property PACKAGE_PIN K18 [get_ports pps_i]
 
-set_property SLEW FAST [get_ports adc_enc_p_o]
-set_property SLEW FAST [get_ports adc_enc_n_o]
+### LED
 
-set_property DRIVE 8 [get_ports adc_enc_p_o]
-set_property DRIVE 8 [get_ports adc_enc_n_o]
+set_property IOSTANDARD LVCMOS33 [get_ports led_o]
+set_property SLEW SLOW [get_ports led_o]
+set_property DRIVE 4 [get_ports led_o]
 
-set_property PACKAGE_PIN N20 [get_ports adc_enc_p_o]
-set_property PACKAGE_PIN P20 [get_ports adc_enc_n_o]
-
-# clock duty cycle stabilizer (CSn)
-
-set_property IOSTANDARD LVCMOS18 [get_ports adc_csn_o]
-set_property PACKAGE_PIN V18 [get_ports adc_csn_o]
-set_property SLEW FAST [get_ports adc_csn_o]
-set_property DRIVE 8 [get_ports adc_csn_o]
-
-### DAC
-
-# data
-
-set_property IOSTANDARD LVCMOS33 [get_ports {dac_dat_o[*]}]
-set_property SLEW SLOW [get_ports {dac_dat_o[*]}]
-set_property DRIVE 4 [get_ports {dac_dat_o[*]}]
-# set_property IOB TRUE [get_ports {dac_dat_o[*]}]
-
-set_property PACKAGE_PIN M19 [get_ports {dac_dat_o[0]}]
-set_property PACKAGE_PIN M20 [get_ports {dac_dat_o[1]}]
-set_property PACKAGE_PIN L19 [get_ports {dac_dat_o[2]}]
-set_property PACKAGE_PIN L20 [get_ports {dac_dat_o[3]}]
-set_property PACKAGE_PIN K19 [get_ports {dac_dat_o[4]}]
-set_property PACKAGE_PIN J19 [get_ports {dac_dat_o[5]}]
-set_property PACKAGE_PIN J20 [get_ports {dac_dat_o[6]}]
-set_property PACKAGE_PIN H20 [get_ports {dac_dat_o[7]}]
-set_property PACKAGE_PIN G19 [get_ports {dac_dat_o[8]}]
-set_property PACKAGE_PIN G20 [get_ports {dac_dat_o[9]}]
-set_property PACKAGE_PIN F19 [get_ports {dac_dat_o[10]}]
-set_property PACKAGE_PIN F20 [get_ports {dac_dat_o[11]}]
-set_property PACKAGE_PIN D20 [get_ports {dac_dat_o[12]}]
-set_property PACKAGE_PIN D19 [get_ports {dac_dat_o[13]}]
-
-# control
-
-set_property IOSTANDARD LVCMOS33 [get_ports dac_*_o]
-set_property SLEW FAST [get_ports dac_*_o]
-set_property DRIVE 8 [get_ports dac_*_o]
-# set_property IOB TRUE [get_ports {dac_*_o}]
-
-set_property PACKAGE_PIN M17 [get_ports dac_wrt_o]
-set_property PACKAGE_PIN N16 [get_ports dac_sel_o]
-set_property PACKAGE_PIN M18 [get_ports dac_clk_o]
-set_property PACKAGE_PIN N15 [get_ports dac_rst_o]
-
-### PWM
-
-set_property IOSTANDARD LVCMOS18 [get_ports {dac_pwm_o[*]}]
-set_property SLEW FAST [get_ports {dac_pwm_o[*]}]
-set_property DRIVE 12 [get_ports {dac_pwm_o[*]}]
-# set_property IOB TRUE [get_ports {dac_pwm_o[*]}]
-
-set_property PACKAGE_PIN T10 [get_ports {dac_pwm_o[0]}]
-set_property PACKAGE_PIN T11 [get_ports {dac_pwm_o[1]}]
-set_property PACKAGE_PIN P15 [get_ports {dac_pwm_o[2]}]
-set_property PACKAGE_PIN U13 [get_ports {dac_pwm_o[3]}]
-
-### XADC
-
-set_property IOSTANDARD LVCMOS33 [get_ports Vp_Vn_v_p]
-set_property IOSTANDARD LVCMOS33 [get_ports Vp_Vn_v_n]
-set_property IOSTANDARD LVCMOS33 [get_ports Vaux0_v_p]
-set_property IOSTANDARD LVCMOS33 [get_ports Vaux0_v_n]
-set_property IOSTANDARD LVCMOS33 [get_ports Vaux1_v_p]
-set_property IOSTANDARD LVCMOS33 [get_ports Vaux1_v_n]
-set_property IOSTANDARD LVCMOS33 [get_ports Vaux8_v_p]
-set_property IOSTANDARD LVCMOS33 [get_ports Vaux8_v_n]
-set_property IOSTANDARD LVCMOS33 [get_ports Vaux9_v_p]
-set_property IOSTANDARD LVCMOS33 [get_ports Vaux9_v_n]
-
-set_property PACKAGE_PIN K9  [get_ports Vp_Vn_v_p]
-set_property PACKAGE_PIN L10 [get_ports Vp_Vn_v_n]
-set_property PACKAGE_PIN C20 [get_ports Vaux0_v_p]
-set_property PACKAGE_PIN B20 [get_ports Vaux0_v_n]
-set_property PACKAGE_PIN E17 [get_ports Vaux1_v_p]
-set_property PACKAGE_PIN D18 [get_ports Vaux1_v_n]
-set_property PACKAGE_PIN B19 [get_ports Vaux8_v_p]
-set_property PACKAGE_PIN A20 [get_ports Vaux8_v_n]
-set_property PACKAGE_PIN E18 [get_ports Vaux9_v_p]
-set_property PACKAGE_PIN E19 [get_ports Vaux9_v_n]
-
+set_property PACKAGE_PIN F16 [get_ports led_o]
 ### Expansion connector
 
 set_property IOSTANDARD LVCMOS33 [get_ports {exp_p_tri_io[*]}]
@@ -161,48 +78,5 @@ set_property PACKAGE_PIN H16 [get_ports {exp_p_tri_io[1]}]
 set_property PACKAGE_PIN H17 [get_ports {exp_n_tri_io[1]}]
 set_property PACKAGE_PIN J18 [get_ports {exp_p_tri_io[2]}]
 set_property PACKAGE_PIN H18 [get_ports {exp_n_tri_io[2]}]
-set_property PACKAGE_PIN K17 [get_ports {exp_p_tri_io[3]}]
-set_property PACKAGE_PIN K18 [get_ports {exp_n_tri_io[3]}]
-set_property PACKAGE_PIN L14 [get_ports {exp_p_tri_io[4]}]
-set_property PACKAGE_PIN L15 [get_ports {exp_n_tri_io[4]}]
-set_property PACKAGE_PIN L16 [get_ports {exp_p_tri_io[5]}]
-set_property PACKAGE_PIN L17 [get_ports {exp_n_tri_io[5]}]
-set_property PACKAGE_PIN K16 [get_ports {exp_p_tri_io[6]}]
-set_property PACKAGE_PIN J16 [get_ports {exp_n_tri_io[6]}]
-set_property PACKAGE_PIN M14 [get_ports {exp_p_tri_io[7]}]
-set_property PACKAGE_PIN M15 [get_ports {exp_n_tri_io[7]}]
 
-### SATA connector
 
-set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports daisy_p_o[*]]
-set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports daisy_n_o[*]]
-
-set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports daisy_p_i[*]]
-set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports daisy_n_i[*]]
-
-set_property PACKAGE_PIN T12 [get_ports {daisy_p_o[0]}]
-set_property PACKAGE_PIN U12 [get_ports {daisy_n_o[0]}]
-
-set_property PACKAGE_PIN U14 [get_ports {daisy_p_o[1]}]
-set_property PACKAGE_PIN U15 [get_ports {daisy_n_o[1]}]
-
-set_property PACKAGE_PIN P14 [get_ports {daisy_p_i[0]}]
-set_property PACKAGE_PIN R14 [get_ports {daisy_n_i[0]}]
-
-set_property PACKAGE_PIN N18 [get_ports {daisy_p_i[1]}]
-set_property PACKAGE_PIN P19 [get_ports {daisy_n_i[1]}]
-
-### LED
-
-set_property IOSTANDARD LVCMOS33 [get_ports {led_o[*]}]
-set_property SLEW SLOW [get_ports {led_o[*]}]
-set_property DRIVE 4 [get_ports {led_o[*]}]
-
-set_property PACKAGE_PIN F16 [get_ports {led_o[0]}]
-set_property PACKAGE_PIN F17 [get_ports {led_o[1]}]
-set_property PACKAGE_PIN G15 [get_ports {led_o[2]}]
-set_property PACKAGE_PIN H15 [get_ports {led_o[3]}]
-set_property PACKAGE_PIN K14 [get_ports {led_o[4]}]
-set_property PACKAGE_PIN G14 [get_ports {led_o[5]}]
-set_property PACKAGE_PIN J15 [get_ports {led_o[6]}]
-set_property PACKAGE_PIN J14 [get_ports {led_o[7]}]

--- a/patches/red_pitaya_fsbl_hooks.c
+++ b/patches/red_pitaya_fsbl_hooks.c
@@ -1,174 +1,536 @@
-#define _GNU_SOURCE
+//SI5351 REFER FROM https://github.com/afiskon/stm32-si5351.git
 
 #include <stdlib.h>
 #include <string.h>
 
 #include "xiicps.h"
 #include "xemacps.h"
+#include "xil_printf.h"
 
 const u8 ADDR_EEPROM = 0x50;
 const u8 ADDR_SI5351 = 0x60;
 
 const u32 XREF_FREQ = 27000000;
 
-static u32 si5351_start(XIicPs* pIic);
-static u32 si5351_setfreq(XIicPs* pIic, unsigned long freq);
+const u32 correction = 0;
+
+
+/* Si5351 driver*/
+
+// Set of Si5351A register addresses
+
+// See http://www.silabs.com/Support%20Documents/TechnicalDocs/AN619.pdf
+enum {
+    SI5351_REGISTER_0_DEVICE_STATUS                       = 0,
+    SI5351_REGISTER_1_INTERRUPT_STATUS_STICKY             = 1,
+    SI5351_REGISTER_2_INTERRUPT_STATUS_MASK               = 2,
+    SI5351_REGISTER_3_OUTPUT_ENABLE_CONTROL               = 3,
+    SI5351_REGISTER_9_OEB_PIN_ENABLE_CONTROL              = 9,
+    SI5351_REGISTER_15_PLL_INPUT_SOURCE                   = 15,
+    SI5351_REGISTER_16_CLK0_CONTROL                       = 16,
+    SI5351_REGISTER_17_CLK1_CONTROL                       = 17,
+    SI5351_REGISTER_18_CLK2_CONTROL                       = 18,
+    SI5351_REGISTER_19_CLK3_CONTROL                       = 19,
+    SI5351_REGISTER_20_CLK4_CONTROL                       = 20,
+    SI5351_REGISTER_21_CLK5_CONTROL                       = 21,
+    SI5351_REGISTER_22_CLK6_CONTROL                       = 22,
+    SI5351_REGISTER_23_CLK7_CONTROL                       = 23,
+    SI5351_REGISTER_24_CLK3_0_DISABLE_STATE               = 24,
+    SI5351_REGISTER_25_CLK7_4_DISABLE_STATE               = 25,
+    SI5351_REGISTER_42_MULTISYNTH0_PARAMETERS_1           = 42,
+    SI5351_REGISTER_43_MULTISYNTH0_PARAMETERS_2           = 43,
+    SI5351_REGISTER_44_MULTISYNTH0_PARAMETERS_3           = 44,
+    SI5351_REGISTER_45_MULTISYNTH0_PARAMETERS_4           = 45,
+    SI5351_REGISTER_46_MULTISYNTH0_PARAMETERS_5           = 46,
+    SI5351_REGISTER_47_MULTISYNTH0_PARAMETERS_6           = 47,
+    SI5351_REGISTER_48_MULTISYNTH0_PARAMETERS_7           = 48,
+    SI5351_REGISTER_49_MULTISYNTH0_PARAMETERS_8           = 49,
+    SI5351_REGISTER_50_MULTISYNTH1_PARAMETERS_1           = 50,
+    SI5351_REGISTER_51_MULTISYNTH1_PARAMETERS_2           = 51,
+    SI5351_REGISTER_52_MULTISYNTH1_PARAMETERS_3           = 52,
+    SI5351_REGISTER_53_MULTISYNTH1_PARAMETERS_4           = 53,
+    SI5351_REGISTER_54_MULTISYNTH1_PARAMETERS_5           = 54,
+    SI5351_REGISTER_55_MULTISYNTH1_PARAMETERS_6           = 55,
+    SI5351_REGISTER_56_MULTISYNTH1_PARAMETERS_7           = 56,
+    SI5351_REGISTER_57_MULTISYNTH1_PARAMETERS_8           = 57,
+    SI5351_REGISTER_58_MULTISYNTH2_PARAMETERS_1           = 58,
+    SI5351_REGISTER_59_MULTISYNTH2_PARAMETERS_2           = 59,
+    SI5351_REGISTER_60_MULTISYNTH2_PARAMETERS_3           = 60,
+    SI5351_REGISTER_61_MULTISYNTH2_PARAMETERS_4           = 61,
+    SI5351_REGISTER_62_MULTISYNTH2_PARAMETERS_5           = 62,
+    SI5351_REGISTER_63_MULTISYNTH2_PARAMETERS_6           = 63,
+    SI5351_REGISTER_64_MULTISYNTH2_PARAMETERS_7           = 64,
+    SI5351_REGISTER_65_MULTISYNTH2_PARAMETERS_8           = 65,
+    SI5351_REGISTER_66_MULTISYNTH3_PARAMETERS_1           = 66,
+    SI5351_REGISTER_67_MULTISYNTH3_PARAMETERS_2           = 67,
+    SI5351_REGISTER_68_MULTISYNTH3_PARAMETERS_3           = 68,
+    SI5351_REGISTER_69_MULTISYNTH3_PARAMETERS_4           = 69,
+    SI5351_REGISTER_70_MULTISYNTH3_PARAMETERS_5           = 70,
+    SI5351_REGISTER_71_MULTISYNTH3_PARAMETERS_6           = 71,
+    SI5351_REGISTER_72_MULTISYNTH3_PARAMETERS_7           = 72,
+    SI5351_REGISTER_73_MULTISYNTH3_PARAMETERS_8           = 73,
+    SI5351_REGISTER_74_MULTISYNTH4_PARAMETERS_1           = 74,
+    SI5351_REGISTER_75_MULTISYNTH4_PARAMETERS_2           = 75,
+    SI5351_REGISTER_76_MULTISYNTH4_PARAMETERS_3           = 76,
+    SI5351_REGISTER_77_MULTISYNTH4_PARAMETERS_4           = 77,
+    SI5351_REGISTER_78_MULTISYNTH4_PARAMETERS_5           = 78,
+    SI5351_REGISTER_79_MULTISYNTH4_PARAMETERS_6           = 79,
+    SI5351_REGISTER_80_MULTISYNTH4_PARAMETERS_7           = 80,
+    SI5351_REGISTER_81_MULTISYNTH4_PARAMETERS_8           = 81,
+    SI5351_REGISTER_82_MULTISYNTH5_PARAMETERS_1           = 82,
+    SI5351_REGISTER_83_MULTISYNTH5_PARAMETERS_2           = 83,
+    SI5351_REGISTER_84_MULTISYNTH5_PARAMETERS_3           = 84,
+    SI5351_REGISTER_85_MULTISYNTH5_PARAMETERS_4           = 85,
+    SI5351_REGISTER_86_MULTISYNTH5_PARAMETERS_5           = 86,
+    SI5351_REGISTER_87_MULTISYNTH5_PARAMETERS_6           = 87,
+    SI5351_REGISTER_88_MULTISYNTH5_PARAMETERS_7           = 88,
+    SI5351_REGISTER_89_MULTISYNTH5_PARAMETERS_8           = 89,
+    SI5351_REGISTER_90_MULTISYNTH6_PARAMETERS             = 90,
+    SI5351_REGISTER_91_MULTISYNTH7_PARAMETERS             = 91,
+    SI5351_REGISTER_92_CLOCK_6_7_OUTPUT_DIVIDER           = 92,
+    SI5351_REGISTER_165_CLK0_INITIAL_PHASE_OFFSET         = 165,
+    SI5351_REGISTER_166_CLK1_INITIAL_PHASE_OFFSET         = 166,
+    SI5351_REGISTER_167_CLK2_INITIAL_PHASE_OFFSET         = 167,
+    SI5351_REGISTER_168_CLK3_INITIAL_PHASE_OFFSET         = 168,
+    SI5351_REGISTER_169_CLK4_INITIAL_PHASE_OFFSET         = 169,
+    SI5351_REGISTER_170_CLK5_INITIAL_PHASE_OFFSET         = 170,
+    SI5351_REGISTER_177_PLL_RESET                         = 177,
+    SI5351_REGISTER_183_CRYSTAL_INTERNAL_LOAD_CAPACITANCE = 183
+};
+
+typedef enum {
+    SI5351_CRYSTAL_LOAD_6PF  = (1<<6),
+    SI5351_CRYSTAL_LOAD_8PF  = (2<<6),
+    SI5351_CRYSTAL_LOAD_10PF = (3<<6)
+} si5351CrystalLoad_t;
+
+typedef enum {
+    SI5351_PLL_A = 0,
+    SI5351_PLL_B,
+} si5351PLL_t;
+
+typedef enum {
+    SI5351_R_DIV_1   = 0,
+    SI5351_R_DIV_2   = 1,
+    SI5351_R_DIV_4   = 2,
+    SI5351_R_DIV_8   = 3,
+    SI5351_R_DIV_16  = 4,
+    SI5351_R_DIV_32  = 5,
+    SI5351_R_DIV_64  = 6,
+    SI5351_R_DIV_128 = 7,
+} si5351RDiv_t;
+
+typedef enum {
+    SI5351_DRIVE_STRENGTH_2MA = 0x00, //  ~ 2.2 dBm
+    SI5351_DRIVE_STRENGTH_4MA = 0x01, //  ~ 7.5 dBm
+    SI5351_DRIVE_STRENGTH_6MA = 0x02, //  ~ 9.5 dBm
+    SI5351_DRIVE_STRENGTH_8MA = 0x03, // ~ 10.7 dBm
+} si5351DriveStrength_t;
+
+typedef struct {
+    u32 mult;
+    u32 num;
+    u32 denom;
+} si5351PLLConfig_t;
+
+typedef struct {
+    u8 allowIntegerMode;
+    u32 div;
+    u32 num;
+    u32 denom;
+    si5351RDiv_t rdiv;
+} si5351OutputConfig_t;
+
+u32 si5351Correction;
+
+// Xilinx I2C Write for common use
+u32 si5351_write(XIicPs* pIic,u8 reg_addr, u8 reg_value)
+{
+    u8 data[2] = {reg_addr, reg_value};
+    u32 Status = XIicPs_MasterSendPolled(pIic, data, sizeof(data), ADDR_SI5351);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    else
+        return XST_SUCCESS;
+}
+
+// Common code for _SetupPLL and _SetupOutput
+u32 si5351_writeBulk(XIicPs* pIic,u8 baseaddr, u32 P1, u32 P2, u32 P3, u8 divBy4, si5351RDiv_t rdiv) {
+    u32 Status;
+    Status = si5351_write(pIic, baseaddr,   (P3 >> 8) & 0xFF);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    Status = si5351_write(pIic, baseaddr+1, P3 & 0xFF);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    Status = si5351_write(pIic, baseaddr+2, ((P1 >> 16) & 0x3) | ((divBy4 & 0x3) << 2) | ((rdiv & 0x7) << 4));
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    Status = si5351_write(pIic, baseaddr+3, (P1 >> 8) & 0xFF);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    Status = si5351_write(pIic, baseaddr+4, P1 & 0xFF);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    Status = si5351_write(pIic, baseaddr+5, ((P3 >> 12) & 0xF0) | ((P2 >> 16) & 0xF));
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    Status = si5351_write(pIic, baseaddr+6, (P2 >> 8) & 0xFF);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    Status = si5351_write(pIic, baseaddr+7, P2 & 0xFF);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    return XST_SUCCESS;
+}
+
+/*
+ * Initializes Si5351. Call this function before doing anything else.
+ * `Correction` is the difference of actual frequency and desired frequency @ 100 MHz.
+ * It can be measured at lower frequencies and scaled linearly.
+ * E.g. if you get 10_000_097 Hz instead of 10_000_000 Hz, `correction` is 97*10 = 970
+ */
+u32 si5351_Init(XIicPs* pIic,u32 correction) {
+    si5351Correction = correction;
+    u32 Status;
+    // Disable all outputs by setting CLKx_DIS high
+    Status = si5351_write(pIic,SI5351_REGISTER_3_OUTPUT_ENABLE_CONTROL, 0xFF);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    // Power down all output drivers
+    Status = si5351_write(pIic,SI5351_REGISTER_16_CLK0_CONTROL, 0x80);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    Status = si5351_write(pIic,SI5351_REGISTER_17_CLK1_CONTROL, 0x80);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    Status = si5351_write(pIic,SI5351_REGISTER_18_CLK2_CONTROL, 0x80);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    Status = si5351_write(pIic,SI5351_REGISTER_19_CLK3_CONTROL, 0x80);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    Status = si5351_write(pIic,SI5351_REGISTER_20_CLK4_CONTROL, 0x80);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    Status = si5351_write(pIic,SI5351_REGISTER_21_CLK5_CONTROL, 0x80);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    Status = si5351_write(pIic,SI5351_REGISTER_22_CLK6_CONTROL, 0x80);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    Status = si5351_write(pIic,SI5351_REGISTER_23_CLK7_CONTROL, 0x80);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+
+    // Set the load capacitance for the XTAL
+    si5351CrystalLoad_t crystalLoad = SI5351_CRYSTAL_LOAD_10PF;
+    Status = si5351_write(pIic,SI5351_REGISTER_183_CRYSTAL_INTERNAL_LOAD_CAPACITANCE, crystalLoad);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+
+    return XST_SUCCESS;
+}
+
+// Sets the multiplier for given PLL
+u32 si5351_SetupPLL(XIicPs* pIic,si5351PLL_t pll, si5351PLLConfig_t* conf) {
+    u32 P1, P2, P3;
+    u32 Status;
+    u32 mult = conf->mult;
+    u32 num = conf->num;
+    u32 denom = conf->denom;
+
+    P1 = 128 * mult + (128 * num)/denom - 512;
+    // P2 = 128 * num - denom * ((128 * num)/denom);
+    P2 = (128 * num) % denom;
+    P3 = denom;
+
+    // Get the appropriate base address for the PLL registers
+    u8 baseaddr = (pll == SI5351_PLL_A ? 26 : 34);
+    Status = si5351_writeBulk(pIic,baseaddr, P1, P2, P3, 0, 0);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    // Reset both PLLs
+    Status = si5351_write(pIic,SI5351_REGISTER_177_PLL_RESET, (1<<7) | (1<<5) );
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    return XST_SUCCESS;
+}
+
+// Configures PLL source, drive strength, multisynth divider, Rdivider and phaseOffset.
+// Returns 0 on success, != 0 otherwise.
+u32 si5351_SetupOutput(XIicPs* pIic,u8 output, si5351PLL_t pllSource, si5351DriveStrength_t driveStrength, si5351OutputConfig_t* conf, u8 phaseOffset) {
+    u32 div = conf->div;
+    u32 num = conf->num;
+    u32 denom = conf->denom;
+    u8 divBy4 = 0;
+    u32 P1, P2, P3;
+    u32 Status;
+
+    if(output > 2) {
+        return 1;
+    }
+
+    if((!conf->allowIntegerMode) && ((div < 8) || ((div == 8) && (num == 0)))) {
+        // div in { 4, 6, 8 } is possible only in integer mode
+        return 2;
+    }
+
+    if(div == 4) {
+        // special DIVBY4 case, see AN619 4.1.3
+        P1 = 0;
+        P2 = 0;
+        P3 = 1;
+        divBy4 = 0x3;
+    } else {
+        P1 = 128 * div + ((128 * num)/denom) - 512;
+        // P2 = 128 * num - denom * (128 * num)/denom;
+        P2 = (128 * num) % denom;
+        P3 = denom;
+    }
+
+    // Get the register addresses for given channel
+    u8 baseaddr = 0;
+    u8 phaseOffsetRegister = 0;
+    u8 clkControlRegister = 0;
+    switch (output) {
+    case 0:
+        baseaddr = SI5351_REGISTER_42_MULTISYNTH0_PARAMETERS_1;
+        phaseOffsetRegister = SI5351_REGISTER_165_CLK0_INITIAL_PHASE_OFFSET;
+        clkControlRegister = SI5351_REGISTER_16_CLK0_CONTROL;
+        break;
+    case 1:
+        baseaddr = SI5351_REGISTER_50_MULTISYNTH1_PARAMETERS_1;
+        phaseOffsetRegister = SI5351_REGISTER_166_CLK1_INITIAL_PHASE_OFFSET;
+        clkControlRegister = SI5351_REGISTER_17_CLK1_CONTROL;
+        break;
+    case 2:
+        baseaddr = SI5351_REGISTER_58_MULTISYNTH2_PARAMETERS_1;
+        phaseOffsetRegister = SI5351_REGISTER_167_CLK2_INITIAL_PHASE_OFFSET;
+        clkControlRegister = SI5351_REGISTER_18_CLK2_CONTROL;
+        break;
+    }
+
+    u8 clkControl = 0x0C | driveStrength; // clock not inverted, powered up
+    if(pllSource == SI5351_PLL_B) {
+        clkControl |= (1 << 5); // Uses PLLB
+    }
+
+    if((conf->allowIntegerMode) && ((num == 0)||(div == 4))) {
+        // use integer mode
+        clkControl |= (1 << 6);
+    }
+
+    Status = si5351_write(pIic,clkControlRegister, clkControl);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    Status = si5351_writeBulk(pIic,baseaddr, P1, P2, P3, divBy4, conf->rdiv);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    Status = si5351_write(pIic,phaseOffsetRegister, (phaseOffset & 0x7F));
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+
+    return XST_SUCCESS;
+}
+
+// Calculates PLL, MS and RDiv settings for given Fclk in [8_000, 160_000_000] range.
+// The actual frequency will differ less than 6 Hz from given Fclk, assuming `correction` is right.
+void si5351_Calc(u32 Fclk, si5351PLLConfig_t* pll_conf, si5351OutputConfig_t* out_conf) {
+    if(Fclk < 8000) Fclk = 8000;
+    else if(Fclk > 160000000) Fclk = 160000000;
+
+    out_conf->allowIntegerMode = 1;
+
+    if(Fclk < 1000000) {
+        // For frequencies in [8_000, 500_000] range we can use si5351_Calc(Fclk*64, ...) and SI5351_R_DIV_64.
+        // In practice it's worth doing for any frequency below 1 MHz, since it reduces the error.
+        Fclk *= 64;
+        out_conf->rdiv = SI5351_R_DIV_64;
+    } else {
+        out_conf->rdiv = SI5351_R_DIV_1;
+    }
+
+    // Apply correction, _after_ determining rdiv.
+    Fclk = Fclk - (u32)((((double)Fclk)/100000000.0)*((double)si5351Correction));
+
+    // Here we are looking for integer values of a,b,c,x,y,z such as:
+    // N = a + b / c    # pll settings
+    // M = x + y / z    # ms  settings
+    // Fclk = Fxtal * N / M
+    // N in [24, 36]
+    // M in [8, 1800] or M in {4,6}
+    // b < c, y < z
+    // b,c,y,z <= 2**20
+    // c, z != 0
+    // For any Fclk in [500K, 160MHz] this algorithm finds a solution
+    // such as abs(Ffound - Fclk) <= 6 Hz
+
+    const u32 Fxtal = XREF_FREQ;
+    u32 a, b, c, x, y, z, t;
+
+    if(Fclk < 81000000) {
+        // Valid for Fclk in 0.5..112.5 MHz range
+        // However an error is > 6 Hz above 81 MHz
+        a = 36; // PLL runs @ 900 MHz
+        b = 0;
+        c = 1;
+        u32 Fpll = 900000000;
+        x = Fpll/Fclk;
+        t = (Fclk >> 20) + 1;
+        y = (Fpll % Fclk) / t;
+        z = Fclk / t;
+    } else {
+        // Valid for Fclk in 75..160 MHz range
+        if(Fclk >= 150000000) {
+            x = 4;
+        } else if (Fclk >= 100000000) {
+            x = 6;
+        } else {
+            x = 8;
+        }
+        y = 0;
+        z = 1;
+
+        u32 numerator = x*Fclk;
+        a = numerator/Fxtal;
+        t = (Fxtal >> 20) + 1;
+        b = (numerator % Fxtal) / t;
+        c = Fxtal / t;
+    }
+
+    pll_conf->mult = a;
+    pll_conf->num = b;
+    pll_conf->denom = c;
+    out_conf->div = x;
+    out_conf->num = y;
+    out_conf->denom = z;
+}
+
+
+// Setup CLK0 for given frequency and drive strength. Use PLLA.
+u32 si5351_SetupCLK0(XIicPs* pIic, u32 Fclk, si5351DriveStrength_t driveStrength) {
+    u32 Status;
+	si5351PLLConfig_t pll_conf;
+	si5351OutputConfig_t out_conf;
+
+	si5351_Calc(Fclk, &pll_conf, &out_conf);
+	Status = si5351_SetupPLL(pIic,SI5351_PLL_A, &pll_conf);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+	Status = si5351_SetupOutput(pIic,0, SI5351_PLL_A, driveStrength, &out_conf, 0);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    return XST_SUCCESS;
+}
+
+// Setup CLK2 for given frequency and drive strength. Use PLLB.
+u32 si5351_SetupCLK2(XIicPs* pIic,u32 Fclk, si5351DriveStrength_t driveStrength) {
+	u32 Status;
+    si5351PLLConfig_t pll_conf;
+	si5351OutputConfig_t out_conf;
+
+	si5351_Calc(Fclk, &pll_conf, &out_conf);
+	Status = si5351_SetupPLL(pIic,SI5351_PLL_B, &pll_conf);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+	Status = si5351_SetupOutput(pIic,2, SI5351_PLL_B, driveStrength, &out_conf, 0);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    return XST_SUCCESS;
+}
+
+// Enables or disables outputs depending on provided bitmask.
+// Examples:
+// si5351_EnableOutputs(1 << 0) enables CLK0 and disables CLK1 and CLK2
+// si5351_EnableOutputs((1 << 2) | (1 << 0)) enables CLK0 and CLK2 and disables CLK1
+u32 si5351_EnableOutputs(XIicPs* pIic,u8 enabled) {
+    u32 Status;
+    Status = si5351_write(pIic,SI5351_REGISTER_3_OUTPUT_ENABLE_CONTROL, ~enabled);
+    if (Status != XST_SUCCESS)
+        return XST_FAILURE;
+    return XST_SUCCESS;
+}
+
 
 u32 SetMacAddress()
 {
-  XIicPs Iic;
-  XIicPs_Config *IicConfig;
-  XEmacPs Emac;
-  XEmacPs_Config *EmacConfig;
-  u32 Status, i;
-  u8 Buffer[1024];
-  char *Pointer;
+    XIicPs Iic;
+    XIicPs_Config *IicConfig;
+    XEmacPs Emac;
+    XEmacPs_Config *EmacConfig;
+    u32 Status, i;
+    u8 Buffer[1024];
+    u32 freq_set;
+    u32 freq_out_set;
+    char *Pointer;
 
-  Buffer[0] = 0x18;
-  Buffer[1] = 0;
+    Buffer[0] = 0x18;
+    Buffer[1] = 0;
+    xil_printf("User RedPitaya Bootloader start\r\n");
+    IicConfig = XIicPs_LookupConfig(XPAR_PS7_I2C_0_DEVICE_ID);
+    if(IicConfig == NULL) return XST_FAILURE;
+    Status = XIicPs_CfgInitialize(&Iic, IicConfig, IicConfig->BaseAddress);
+    if(Status != XST_SUCCESS) return XST_FAILURE;
+    Status = XIicPs_SetSClk(&Iic, 100000);
+    if(Status != XST_SUCCESS) return XST_FAILURE;
+    Status = XIicPs_MasterSendPolled(&Iic, Buffer, 2, ADDR_EEPROM);
+    if(Status != XST_SUCCESS) return XST_FAILURE;
+    while(XIicPs_BusIsBusy(&Iic));
+    Status = XIicPs_MasterRecvPolled(&Iic, Buffer, 1024, ADDR_EEPROM);
+    if(Status != XST_SUCCESS) return XST_FAILURE;
+    Pointer = memmem(Buffer, 1024, "ethaddr=", 8);
+    if(Pointer == NULL) return XST_FAILURE;
+    Pointer += 7;
+    xil_printf("MAC address read from EEPROM:\r\n");
+    for(i = 0; i < 6; ++i)
+    {
+        Buffer[i] = strtol(Pointer + 1, &Pointer, 16);
+        xil_printf("%2x",Buffer[i]);
+        if(i < 5)
+            xil_printf(":");
+    }
+    
+    xil_printf("\r\n");
 
-  IicConfig = XIicPs_LookupConfig(XPAR_PS7_I2C_0_DEVICE_ID);
-  if(IicConfig == NULL) return XST_FAILURE;
+    EmacConfig = XEmacPs_LookupConfig(XPAR_PS7_ETHERNET_0_DEVICE_ID);
+    if(EmacConfig == NULL) return XST_FAILURE;
+    Status = XEmacPs_CfgInitialize(&Emac, EmacConfig, EmacConfig->BaseAddress);
+    if(Status != XST_SUCCESS) return XST_FAILURE;
+    Status = XEmacPs_SetMacAddress(&Emac, Buffer, 1);
+    if(Status != XST_SUCCESS) return XST_FAILURE;
+    xil_printf("Bootloader Si5351 config\r\n");
+    Pointer = memmem(Buffer, 1024, "clk_freq=", 9);
+    if(Pointer != NULL) {
+        Pointer += 8;
+        freq_set = strtol(Pointer + 1, &Pointer, 10);
+        xil_printf("EEPROM adc clk freq set :%dHz\r\n",freq_set);
+    }
+    else {
+    	xil_printf("EEPROM read adc clk freq failed.Set to default 125Mhz\r\n");
+        freq_set = 125000000;
+    }
+    
+    Pointer = memmem(Buffer, 1024, "clk_out_freq=", 13);
+    if(Pointer != NULL) {
+        Pointer += 12;
+        freq_out_set = strtol(Pointer + 1, &Pointer, 10);
+        xil_printf("EEPROM clk out freq set :%dHz\r\n",freq_out_set);
+    }
+    else {
+    	xil_printf("EEPROM read clk out freq failed.Set to default 10Mhz\r\n");
+        freq_out_set = 10000000;
+    }
 
-  Status = XIicPs_CfgInitialize(&Iic, IicConfig, IicConfig->BaseAddress);
-  if(Status != XST_SUCCESS) return XST_FAILURE;
-
-  Status = XIicPs_SetSClk(&Iic, 100000);
-  if(Status != XST_SUCCESS) return XST_FAILURE;
-
-  Status = XIicPs_MasterSendPolled(&Iic, Buffer, 2, ADDR_EEPROM);
-  if(Status != XST_SUCCESS) return XST_FAILURE;
-
-  while(XIicPs_BusIsBusy(&Iic));
-
-  Status = XIicPs_MasterRecvPolled(&Iic, Buffer, 1024, ADDR_EEPROM);
-  if(Status != XST_SUCCESS) return XST_FAILURE;
-
-  Pointer = memmem(Buffer, 1024, "ethaddr=", 8);
-  if(Pointer == NULL) return XST_FAILURE;
-
-  Pointer += 7;
-  for(i = 0; i < 6; ++i)
-  {
-    Buffer[i] = strtol(Pointer + 1, &Pointer, 16);
-  }
-
-  EmacConfig = XEmacPs_LookupConfig(XPAR_PS7_ETHERNET_0_DEVICE_ID);
-  if(EmacConfig == NULL) return XST_FAILURE;
-
-  Status = XEmacPs_CfgInitialize(&Emac, EmacConfig, EmacConfig->BaseAddress);
-  if(Status != XST_SUCCESS) return XST_FAILURE;
-
-  Status = XEmacPs_SetMacAddress(&Emac, Buffer, 1);
-  if(Status != XST_SUCCESS) return XST_FAILURE;
-
-  /* Set Si5351 to 122.88MHz */
-  Status = si5351_start(&Iic);
-  if (Status != XST_SUCCESS) return XST_FAILURE;
-
-  Status = si5351_setfreq(&Iic, 125000000);
-  if (Status != XST_SUCCESS) return XST_FAILURE;
-
-  return Status;
-}
-
-/* Si5351 simple driver*/
-// Set of Si5351A register addresses
-#define CLK_ENABLE_CONTROL 3
-#define PLLX_SRC 15
-#define CLK0_CONTROL 16
-#define CLK1_CONTROL 17
-#define CLK2_CONTROL 18
-#define SYNTH_PLL_A 26
-#define SYNTH_PLL_B 34
-#define SYNTH_MS_0 42
-#define SYNTH_MS_1 50
-#define SYNTH_MS_2 58
-#define PLL_RESET 177
-#define XTAL_LOAD_CAP 183
-
-#define si5351_write(reg_addr, reg_value)                                        \
-  do                                                                             \
-  {                                                                              \
-    u8 data[2] = {(u8)reg_addr, (u8)reg_value};                                  \
-    u32 Status = XIicPs_MasterSendPolled(pIic, data, sizeof(data), ADDR_SI5351); \
-    if (Status != XST_SUCCESS)                                                   \
-      return XST_FAILURE;                                                        \
-  } while (0)
-
-// Set PLLs (VCOs) to internal clock rate of 900 MHz
-// Equation fVCO = fXTAL * (a+b/c) (=> AN619 p. 3
-u32 si5351_start(XIicPs *pIic)
-{
-  unsigned long a, b, c;
-  unsigned long p1, p2, p3;
-
-  // Init clock chip
-  si5351_write(XTAL_LOAD_CAP, 0xD2);      // Set crystal load capacitor to 10pF (default),
-                                          // for bits 5:0 see also AN619 p. 60
-  si5351_write(CLK_ENABLE_CONTROL, 0xFE); // Enable CLK 0 only
-  si5351_write(CLK0_CONTROL, 0x0F);       // Set PLLA to CLK0, 8 mA output
-  si5351_write(CLK1_CONTROL, 0x2F);       // Set PLLB to CLK1, 8 mA output
-  si5351_write(CLK2_CONTROL, 0x2F);       // Set PLLB to CLK2, 8 mA output
-  si5351_write(PLL_RESET, 0xA0);          // Reset PLLA and PLLB
-
-  // Set VCOs of PLLA and PLLB to 900 MHz
-  a = 36;      // Division factor 900/25 MHz
-  b = 0;       // Numerator, sets b/c=0
-  c = 1048575; // Max. resolution, but irrelevant in this case (b=0)
-
-  // Formula for splitting up the numbers to register data, see AN619
-  p1 = 128 * a + (unsigned long)(128 * b / c) - 512;
-  p2 = 128 * b - c * (unsigned long)(128 * b / c);
-  p3 = c;
-
-  // Write data to registers PLLA and PLLB so that both VCOs are set to 900MHz intermal freq
-  si5351_write(SYNTH_PLL_A, 0xFF);
-  si5351_write(SYNTH_PLL_A + 1, 0xFF);
-  si5351_write(SYNTH_PLL_A + 2, (p1 & 0x00030000) >> 16);
-  si5351_write(SYNTH_PLL_A + 3, (p1 & 0x0000FF00) >> 8);
-  si5351_write(SYNTH_PLL_A + 4, (p1 & 0x000000FF));
-  si5351_write(SYNTH_PLL_A + 5, 0xF0 | ((p2 & 0x000F0000) >> 16));
-  si5351_write(SYNTH_PLL_A + 6, (p2 & 0x0000FF00) >> 8);
-  si5351_write(SYNTH_PLL_A + 7, (p2 & 0x000000FF));
-
-  si5351_write(SYNTH_PLL_B, 0xFF);
-  si5351_write(SYNTH_PLL_B + 1, 0xFF);
-  si5351_write(SYNTH_PLL_B + 2, (p1 & 0x00030000) >> 16);
-  si5351_write(SYNTH_PLL_B + 3, (p1 & 0x0000FF00) >> 8);
-  si5351_write(SYNTH_PLL_B + 4, (p1 & 0x000000FF));
-  si5351_write(SYNTH_PLL_B + 5, 0xF0 | ((p2 & 0x000F0000) >> 16));
-  si5351_write(SYNTH_PLL_B + 6, (p2 & 0x0000FF00) >> 8);
-  si5351_write(SYNTH_PLL_B + 7, (p2 & 0x000000FF));
-
-  return XST_SUCCESS;
-}
-
-u32 si5351_setfreq(XIicPs *pIic, unsigned long freq)
-{
-  int synth = SYNTH_MS_0;
-  unsigned long a, b, c = 1048575;
-  unsigned long f_xtal = XREF_FREQ;
-  double fdiv = (double)(f_xtal * 36) / freq; // division factor fvco/freq (will be integer part of a+b/c)
-  double rm;                                  // remainder
-  unsigned long p1, p2, p3;
-
-  a = (unsigned long)fdiv;
-  rm = fdiv - a; //(equiv. b/c)
-  b = rm * c;
-  p1 = 128 * a + (unsigned long)(128 * b / c) - 512;
-  p2 = 128 * b - c * (unsigned long)(128 * b / c);
-  p3 = c;
-
-  // Write data to multisynth registers of synth n
-  si5351_write(synth, 0xFF);     // 1048757 MSB
-  si5351_write(synth + 1, 0xFF); // 1048757 LSB
-  si5351_write(synth + 2, (p1 & 0x00030000) >> 16);
-  si5351_write(synth + 3, (p1 & 0x0000FF00) >> 8);
-  si5351_write(synth + 4, (p1 & 0x000000FF));
-  si5351_write(synth + 5, 0xF0 | ((p2 & 0x000F0000) >> 16));
-  si5351_write(synth + 6, (p2 & 0x0000FF00) >> 8);
-  si5351_write(synth + 7, (p2 & 0x000000FF));
-
-  return XST_SUCCESS;
+    /* Set Si5351 to Set freq */
+    Status = si5351_Init(&Iic,correction);
+    if (Status != XST_SUCCESS) return XST_FAILURE;
+    Status = si5351_SetupCLK0(&Iic,freq_set, SI5351_DRIVE_STRENGTH_6MA);
+    if (Status != XST_SUCCESS) return XST_FAILURE;
+    Status = si5351_SetupCLK2(&Iic,freq_out_set, SI5351_DRIVE_STRENGTH_6MA);
+    if (Status != XST_SUCCESS) return XST_FAILURE;
+    Status = si5351_EnableOutputs(&Iic,(1<<0) | (1<<2));
+    if (Status != XST_SUCCESS) return XST_FAILURE;
+    xil_printf("Bootloader config success,boot to Linux\r\n");
+    return XST_SUCCESS;
 }

--- a/projects/common_tools/block_design.tcl
+++ b/projects/common_tools/block_design.tcl
@@ -34,7 +34,7 @@ cell pavel-demin:user:port_slicer cfg_slice_0 {
 
 # Create port_slicer
 cell pavel-demin:user:port_slicer led_slice_0 {
-  DIN_WIDTH 64 DIN_FROM 23 DIN_TO 16
+  DIN_WIDTH 64 DIN_FROM 16 DIN_TO 16
 } {
   din hub_0/cfg_data
   dout /led_o
@@ -46,11 +46,11 @@ cell pavel-demin:user:port_slicer led_slice_0 {
 delete_bd_objs [get_bd_ports /exp_p_tri_io]
 
 # Create output port
-create_bd_port -dir O -from 7 -to 0 exp_p_tri_io
+create_bd_port -dir O -from 2 -to 0 exp_p_tri_io
 
 # Create port_slicer
 cell pavel-demin:user:port_slicer out_slice_0 {
-  DIN_WIDTH 64 DIN_FROM 31 DIN_TO 24
+  DIN_WIDTH 64 DIN_FROM 26 DIN_TO 24
 } {
   din hub_0/cfg_data
   dout /exp_p_tri_io
@@ -60,13 +60,13 @@ cell pavel-demin:user:port_slicer out_slice_0 {
 delete_bd_objs [get_bd_ports /exp_n_tri_io]
 
 # Create input port
-create_bd_port -dir I -from 3 -to 0 exp_n_tri_io
+create_bd_port -dir I -from 2 -to 0 exp_n_tri_io
 
 # Create port_slicer
 cell pavel-demin:user:port_slicer pps_slice_0 {
-  DIN_WIDTH 4 DIN_FROM 3 DIN_TO 3
+  DIN_WIDTH 1 DIN_FROM 1 DIN_TO 1
 } {
-  din /exp_n_tri_io
+  din /pps_i
   dout /ps_0/GPIO_I
 }
 

--- a/projects/sdr_receiver/block_design.tcl
+++ b/projects/sdr_receiver/block_design.tcl
@@ -39,6 +39,11 @@ cell xilinx.com:ip:xlconstant const_adc_ditch {
   CONST_VAL 0
 }
 
+cell xilinx.com:ip:xlconstant const_adc_pga {
+  CONST_WIDTH 1
+  CONST_VAL 0
+}
+
 # Create proc_sys_reset
 cell xilinx.com:ip:proc_sys_reset rst_0 {} {
   ext_reset_in const_0/dout
@@ -66,4 +71,5 @@ module rx_0 {
 }
 
 wire adc_dith_o const_adc_ditch/dout
+wire adc_pga_o const_adc_pga/dout
 

--- a/projects/sdr_receiver/block_design.tcl
+++ b/projects/sdr_receiver/block_design.tcl
@@ -29,6 +29,16 @@ apply_bd_automation -rule xilinx.com:bd_rule:processing_system7 -config {
 # Create xlconstant
 cell xilinx.com:ip:xlconstant const_0
 
+cell xilinx.com:ip:xlconstant const_adc_dummy_b {
+  CONST_WIDTH 16
+  CONST_VAL 0
+}
+
+cell xilinx.com:ip:xlconstant const_adc_ditch {
+  CONST_WIDTH 1
+  CONST_VAL 0
+}
+
 # Create proc_sys_reset
 cell xilinx.com:ip:proc_sys_reset rst_0 {} {
   ext_reset_in const_0/dout
@@ -44,8 +54,7 @@ cell pavel-demin:user:axis_red_pitaya_adc adc_0 {
 } {
   aclk pll_0/clk_out1
   adc_dat_a adc_dat_a_i
-  adc_dat_b adc_dat_b_i
-  adc_csn adc_csn_o
+  adc_dat_b const_adc_dummy_b/dout
 }
 
 # RX 0
@@ -55,3 +64,6 @@ module rx_0 {
 } {
   hub_0/S_AXI ps_0/M_AXI_GP0
 }
+
+wire adc_dith_o const_adc_ditch/dout
+

--- a/projects/sdr_receiver_hpsdr/block_design.tcl
+++ b/projects/sdr_receiver_hpsdr/block_design.tcl
@@ -29,6 +29,21 @@ apply_bd_automation -rule xilinx.com:bd_rule:processing_system7 -config {
 # Create xlconstant
 cell xilinx.com:ip:xlconstant const_0
 
+cell xilinx.com:ip:xlconstant const_adc_dummy_b {
+  CONST_WIDTH 16
+  CONST_VAL 0
+}
+
+cell xilinx.com:ip:xlconstant const_adc_ditch {
+  CONST_WIDTH 1
+  CONST_VAL 0
+}
+
+cell xilinx.com:ip:xlconstant const_adc_pga {
+  CONST_WIDTH 1
+  CONST_VAL 0
+}
+
 # Create proc_sys_reset
 cell xilinx.com:ip:proc_sys_reset rst_0 {} {
   ext_reset_in const_0/dout
@@ -44,8 +59,7 @@ cell pavel-demin:user:axis_red_pitaya_adc adc_0 {
 } {
   aclk pll_0/clk_out1
   adc_dat_a adc_dat_a_i
-  adc_dat_b adc_dat_b_i
-  adc_csn adc_csn_o
+  adc_dat_b const_adc_dummy_b/dout
 }
 
 # RX 0
@@ -55,3 +69,7 @@ module rx_0 {
 } {
   hub_0/S_AXI ps_0/M_AXI_GP0
 }
+
+wire adc_dith_o const_adc_ditch/dout
+wire adc_pga_o const_adc_pga/dout
+

--- a/projects/sdr_receiver_wide/block_design.tcl
+++ b/projects/sdr_receiver_wide/block_design.tcl
@@ -38,6 +38,21 @@ apply_bd_automation -rule xilinx.com:bd_rule:processing_system7 -config {
 # Create xlconstant
 cell xilinx.com:ip:xlconstant const_0
 
+cell xilinx.com:ip:xlconstant const_adc_dummy_b {
+  CONST_WIDTH 16
+  CONST_VAL 0
+}
+
+cell xilinx.com:ip:xlconstant const_adc_ditch {
+  CONST_WIDTH 1
+  CONST_VAL 0
+}
+
+cell xilinx.com:ip:xlconstant const_adc_pga {
+  CONST_WIDTH 1
+  CONST_VAL 0
+}
+
 # Create proc_sys_reset
 cell xilinx.com:ip:proc_sys_reset rst_0 {} {
   ext_reset_in const_0/dout
@@ -53,27 +68,9 @@ cell pavel-demin:user:axis_red_pitaya_adc adc_0 {
 } {
   aclk pll_0/clk_out1
   adc_dat_a adc_dat_a_i
-  adc_dat_b adc_dat_b_i
-  adc_csn adc_csn_o
+  adc_dat_b const_adc_dummy_b/dout
 }
 
-# DAC
-
-# Create axis_red_pitaya_dac
-cell pavel-demin:user:axis_red_pitaya_dac dac_0 {
-  DAC_DATA_WIDTH 14
-} {
-  aclk pll_0/clk_out1
-  ddr_clk pll_0/clk_out2
-  wrt_clk pll_0/clk_out3
-  locked pll_0/locked
-  dac_clk dac_clk_o
-  dac_rst dac_rst_o
-  dac_sel dac_sel_o
-  dac_wrt dac_wrt_o
-  dac_dat dac_dat_o
-  s_axis_tvalid const_0/dout
-}
 
 # HUB
 
@@ -319,37 +316,6 @@ cell pavel-demin:user:axis_ram_writer writer_0 {
   aresetn slice_1/dout
 }
 
-# GEN
+wire adc_dith_o const_adc_ditch/dout
+wire adc_pga_o const_adc_pga/dout
 
-for {set i 0} {$i <= 1} {incr i} {
-
-  # Create port_slicer
-  cell pavel-demin:user:port_slicer slice_[expr $i + 8] {
-    DIN_WIDTH 224 DIN_FROM [expr 16 * $i + 207] DIN_TO [expr 16 * $i + 192]
-  } {
-    din hub_0/cfg_data
-  }
-
-  # Create dsp48
-  cell pavel-demin:user:dsp48 mult_[expr $i + 4] {
-    A_WIDTH 24
-    B_WIDTH 16
-    P_WIDTH 14
-  } {
-    A dds_[expr $i + 2]/m_axis_data_tdata
-    B slice_[expr $i + 8]/dout
-    CLK pll_0/clk_out1
-  }
-
-}
-
-# Create xlconcat
-cell xilinx.com:ip:xlconcat concat_0 {
-  NUM_PORTS 2
-  IN0_WIDTH 16
-  IN1_WIDTH 16
-} {
-  In0 mult_4/P
-  In1 mult_5/P
-  dout dac_0/s_axis_tdata
-}

--- a/projects/sdr_transceiver_ft8/block_design.tcl
+++ b/projects/sdr_transceiver_ft8/block_design.tcl
@@ -37,6 +37,21 @@ apply_bd_automation -rule xilinx.com:bd_rule:processing_system7 -config {
 # Create xlconstant
 cell xilinx.com:ip:xlconstant const_0
 
+cell xilinx.com:ip:xlconstant const_adc_dummy_b {
+  CONST_WIDTH 16
+  CONST_VAL 0
+}
+
+cell xilinx.com:ip:xlconstant const_adc_ditch {
+  CONST_WIDTH 1
+  CONST_VAL 0
+}
+
+cell xilinx.com:ip:xlconstant const_adc_pga {
+  CONST_WIDTH 1
+  CONST_VAL 0
+}
+
 # Create proc_sys_reset
 cell xilinx.com:ip:proc_sys_reset rst_0 {} {
   ext_reset_in const_0/dout
@@ -52,25 +67,7 @@ cell pavel-demin:user:axis_red_pitaya_adc adc_0 {
 } {
   aclk pll_0/clk_out1
   adc_dat_a adc_dat_a_i
-  adc_dat_b adc_dat_b_i
-  adc_csn adc_csn_o
-}
-
-# DAC
-
-# Create axis_red_pitaya_dac
-cell pavel-demin:user:axis_red_pitaya_dac dac_0 {
-  DAC_DATA_WIDTH 14
-} {
-  aclk pll_0/clk_out1
-  ddr_clk pll_0/clk_out2
-  wrt_clk pll_0/clk_out3
-  locked pll_0/locked
-  dac_clk dac_clk_o
-  dac_rst dac_rst_o
-  dac_sel dac_sel_o
-  dac_wrt dac_wrt_o
-  dac_dat dac_dat_o
+  adc_dat_b const_adc_dummy_b/dout
 }
 
 # HUB
@@ -125,34 +122,13 @@ module rx_0 {
   conv_2/M_AXIS hub_0/S00_AXIS
 }
 
-# TX 0
-
-# Create port_slicer
-cell pavel-demin:user:port_slicer rst_slice_1 {
-  DIN_WIDTH 352 DIN_FROM 15 DIN_TO 8
-} {
-  din hub_0/cfg_data
-}
-
-# Create port_slicer
-cell pavel-demin:user:port_slicer cfg_slice_1 {
-  DIN_WIDTH 352 DIN_FROM 351 DIN_TO 320
-} {
-  din hub_0/cfg_data
-}
-
-module tx_0 {
-  source projects/sdr_transceiver_ft8/tx.tcl
-} {
-  slice_0/din rst_slice_1/dout
-  slice_1/din cfg_slice_1/dout
-  slice_2/din cfg_slice_1/dout
-  fifo_0/S_AXIS hub_0/M00_AXIS
-  zeroer_0/M_AXIS dac_0/S_AXIS
-}
 
 # GPIO, PPS and level measurement
 
 module common_0 {
   source projects/common_tools/block_design.tcl
 }
+
+wire adc_dith_o const_adc_ditch/dout
+wire adc_pga_o const_adc_pga/dout
+

--- a/projects/sdr_transceiver_wspr/block_design.tcl
+++ b/projects/sdr_transceiver_wspr/block_design.tcl
@@ -37,6 +37,21 @@ apply_bd_automation -rule xilinx.com:bd_rule:processing_system7 -config {
 # Create xlconstant
 cell xilinx.com:ip:xlconstant const_0
 
+cell xilinx.com:ip:xlconstant const_adc_dummy_b {
+  CONST_WIDTH 16
+  CONST_VAL 0
+}
+
+cell xilinx.com:ip:xlconstant const_adc_ditch {
+  CONST_WIDTH 1
+  CONST_VAL 0
+}
+
+cell xilinx.com:ip:xlconstant const_adc_pga {
+  CONST_WIDTH 1
+  CONST_VAL 0
+}
+
 # Create proc_sys_reset
 cell xilinx.com:ip:proc_sys_reset rst_0 {} {
   ext_reset_in const_0/dout
@@ -52,26 +67,9 @@ cell pavel-demin:user:axis_red_pitaya_adc adc_0 {
 } {
   aclk pll_0/clk_out1
   adc_dat_a adc_dat_a_i
-  adc_dat_b adc_dat_b_i
-  adc_csn adc_csn_o
+  adc_dat_b const_adc_dummy_b/dout
 }
 
-# DAC
-
-# Create axis_red_pitaya_dac
-cell pavel-demin:user:axis_red_pitaya_dac dac_0 {
-  DAC_DATA_WIDTH 14
-} {
-  aclk pll_0/clk_out1
-  ddr_clk pll_0/clk_out2
-  wrt_clk pll_0/clk_out3
-  locked pll_0/locked
-  dac_clk dac_clk_o
-  dac_rst dac_rst_o
-  dac_sel dac_sel_o
-  dac_wrt dac_wrt_o
-  dac_dat dac_dat_o
-}
 
 # HUB
 
@@ -125,34 +123,13 @@ module rx_0 {
   conv_2/M_AXIS hub_0/S00_AXIS
 }
 
-# TX 0
-
-# Create port_slicer
-cell pavel-demin:user:port_slicer rst_slice_1 {
-  DIN_WIDTH 352 DIN_FROM 15 DIN_TO 8
-} {
-  din hub_0/cfg_data
-}
-
-# Create port_slicer
-cell pavel-demin:user:port_slicer cfg_slice_1 {
-  DIN_WIDTH 352 DIN_FROM 351 DIN_TO 320
-} {
-  din hub_0/cfg_data
-}
-
-module tx_0 {
-  source projects/sdr_transceiver_wspr/tx.tcl
-} {
-  slice_0/din rst_slice_1/dout
-  slice_1/din cfg_slice_1/dout
-  slice_2/din cfg_slice_1/dout
-  fifo_0/S_AXIS hub_0/M00_AXIS
-  zeroer_0/M_AXIS dac_0/S_AXIS
-}
 
 # GPIO, PPS and level measurement
 
 module common_0 {
   source projects/common_tools/block_design.tcl
 }
+
+wire adc_dith_o const_adc_ditch/dout
+wire adc_pga_o const_adc_pga/dout
+


### PR DESCRIPTION
Web888 bootloader si5351 driver
Use fw_setenv to set and fw_printenv to check.
adc_clk: fw_set_env clk_freq [freq Hz] (Default is 125000000)
ext_clk: fw_set_env clk_out_freq [freq Hz] (Default is 10000000)